### PR TITLE
Update global.hpp

### DIFF
--- a/include/boost/mixin/global.hpp
+++ b/include/boost/mixin/global.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/assert.hpp>
 #include <algorithm>
+#include <functional> // for std::greater
 #include <vector>
 #include <cstring> // for memset
 


### PR DESCRIPTION
gcc and msvc seem to drag std::greater<> from agorithm but emscripten (with clang in it?) does not.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ibob/boost.mixin/7)

<!-- Reviewable:end -->
